### PR TITLE
Fix broken error handling

### DIFF
--- a/service-now.js
+++ b/service-now.js
@@ -94,6 +94,9 @@ class ServiceNow {
             } catch(e) {
                 var res = body
             }
+            if(!err && res.__error) {
+                err = res.__error;
+            }
             let jsonRes = res.records;
             callback(err, jsonRes)
         });


### PR DESCRIPTION
Certain errors aren't handled properly. In such cases the the callback is called like so `callback(null, undefined)`, while the http response actually contains an object with an `__error` field, which isn't checked.
This commit addresses that issue by setting `err` to `res.__error` in case `err` evaluates to false (read: isn't set to an error yet,) and `res.__error` evaluates to `true`.